### PR TITLE
feat!: require Node.js 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,18 +7,21 @@
     "i18n",
     "internationalization"
   ],
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/gen-i18n-ts.git"
   },
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
-  "type": "module",
   "bin": "./bin/index.js",
   "files": [
     "bin/",
     "dist/"
   ],
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "build-ts app",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -35,7 +38,6 @@
     "test": "yarn vitest run",
     "typecheck": "tsgo --noEmit"
   },
-  "prettier": "@willbooster/prettier-config",
   "dependencies": {
     "js-yaml": "4.1.1",
     "yargs": "18.0.0"
@@ -71,11 +73,9 @@
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"
   },
-  "packageManager": "yarn@4.14.1",
+  "prettier": "@willbooster/prettier-config",
   "engines": {
     "node": ">=24"
   },
-  "publishConfig": {
-    "access": "public"
-  }
+  "packageManager": "yarn@4.14.1"
 }

--- a/package.json
+++ b/package.json
@@ -7,21 +7,18 @@
     "i18n",
     "internationalization"
   ],
-  "license": "Apache-2.0",
-  "author": "WillBooster Inc.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/WillBooster/gen-i18n-ts.git"
   },
+  "license": "Apache-2.0",
+  "author": "WillBooster Inc.",
+  "type": "module",
   "bin": "./bin/index.js",
   "files": [
     "bin/",
     "dist/"
   ],
-  "type": "module",
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "build-ts app",
     "check-all-for-ai": "yarn check-for-ai && yarn test",
@@ -38,6 +35,7 @@
     "test": "yarn vitest run",
     "typecheck": "tsgo --noEmit"
   },
+  "prettier": "@willbooster/prettier-config",
   "dependencies": {
     "js-yaml": "4.1.1",
     "yargs": "18.0.0"
@@ -73,9 +71,11 @@
     "sort-package-json": "3.6.1",
     "vitest": "4.1.4"
   },
-  "prettier": "@willbooster/prettier-config",
+  "packageManager": "yarn@4.14.1",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
-  "packageManager": "yarn@4.14.1"
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
## Summary
- raise the published Node.js engine requirement from >=20 to >=24
- use a breaking conventional commit so semantic-release can publish the next major version instead of retrying the burned 3.2.0 version

## Verification
- yarn check-for-ai
- pre-push check