### PR TITLE
fix: order generated i18n hook helpers

### DIFF
--- a/src/codeGenerator.ts
+++ b/src/codeGenerator.ts
@@ -123,6 +123,8 @@ export const LocaleProvider: React.FC<LocaleProviderProps> = ({ children }) => {
   return <LocaleContext.Provider value={{ locale, setLocale }}>{children}</LocaleContext.Provider>;
 };
 
+${useI18nCode}
+
 export function useLocaleValue(): SupportedLanguage {
   return useLocaleContext().locale;
 }
@@ -130,8 +132,6 @@ export function useLocaleValue(): SupportedLanguage {
 export function useSetLocale(): (locale: string) => boolean {
   return useLocaleContext().setLocale;
 }
-
-${useI18nCode}
 
 function useLocaleContext(): LocaleContextValue {
   const context = useContext(LocaleContext);


### PR DESCRIPTION
## Summary

- move generated useI18n above the hooks it calls in the Next client helper
- keep generated helpers aligned with the top-down function-ordering convention

## Testing

- yarn build
- yarn check-for-ai