### PR TITLE
fix: preserve hash in generated locale switch

### DIFF
--- a/src/codeGenerator.ts
+++ b/src/codeGenerator.ts
@@ -117,7 +117,8 @@ export const LocaleProvider: React.FC<LocaleProviderProps> = ({ children }) => {
     setLocalePreference(newLocale);
     const nextPathname = replaceLocaleSegment(pathname, locale, newLocale);
     const query = getCurrentSearchParams();
-    router.push(query ? \`\${nextPathname}?\${query}\` : nextPathname);
+    const hash = getCurrentHash();
+    router.push(\`\${nextPathname}\${query ? \`?\${query}\` : ''}\${hash}\`);
     return true;
   };
 
@@ -183,6 +184,11 @@ function setLocalePreference(locale: SupportedLanguage): void {
 function getCurrentSearchParams(): string {
   if (!('window' in globalThis)) return '';
   return globalThis.location.search.replace(/^\\?/, '');
+}
+
+function getCurrentHash(): string {
+  if (!('window' in globalThis)) return '';
+  return globalThis.location.hash;
 }
 
 function replaceLocaleSegment(pathname: string, currentLocale: SupportedLanguage, nextLocale: SupportedLanguage): string {


### PR DESCRIPTION
## Summary

- preserve the current URL hash when generated Next helpers switch locale
- add a small generated helper for reading location.hash only on the client

## Testing

- yarn build
- yarn check-for-ai